### PR TITLE
Add dashboard-based Toolbox application with PDF, screenshot and conversion tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+/dist/
+/build/
+/venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # Toolbox
+
+Toolbox is a small collection of desktop utilities with a dashboard
+interface reminiscent of Parallels Toolbox. It currently includes:
+
+* **PDF Annotator** – open a PDF, draw freehand annotations or insert
+  text and save the result.
+* **Screenshot** – capture the whole screen or a user-defined region.
+* **Converter** – convert images and PDF files to various formats with
+  optional resizing, DPI adjustment and grayscale conversion.
+* Two demonstration tiles reserved for future tools.
+
+The application is written in Python with Tkinter for the interface and
+relies on [Pillow](https://python-pillow.org) and
+[PyMuPDF](https://pymupdf.readthedocs.io/) for media handling.
+
+## Running from source
+
+```bash
+pip install -r requirements.txt
+python -m toolbox.main
+```
+
+## Packaging for Windows
+
+A batch script is provided to create a standalone executable using
+[PyInstaller](https://pyinstaller.org/):
+
+```
+build.bat
+```
+
+The generated executable will appear in the `dist` directory.
+
+## Adding new tools
+
+Each tool lives in its own module. To add a new utility, create a new
+Python file in the `toolbox` package and add a button in
+`toolbox/main.py`.

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,8 @@
+@echo off
+REM Build standalone executable using PyInstaller
+if not exist venv (
+    python -m venv venv
+)
+call venv\Scripts\activate
+pip install -r requirements.txt pyinstaller
+pyinstaller --noconfirm --onefile --windowed toolbox\main.py --name Toolbox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyMuPDF
+Pillow

--- a/toolbox/__init__.py
+++ b/toolbox/__init__.py
@@ -1,0 +1,1 @@
+"""Toolbox package containing utilities."""

--- a/toolbox/converter.py
+++ b/toolbox/converter.py
@@ -1,0 +1,122 @@
+"""Image and PDF conversion utility."""
+
+from __future__ import annotations
+
+import os
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+try:
+    from PIL import Image
+except Exception as exc:  # pylint: disable=broad-except
+    raise ImportError(
+        "Pillow is required for the converter. Please install it before running."  # noqa: E501
+    ) from exc
+
+try:
+    import fitz  # PyMuPDF
+except Exception as exc:  # pylint: disable=broad-except
+    raise ImportError(
+        "PyMuPDF is required for the converter. Please install it before running."  # noqa: E501
+    ) from exc
+
+
+class ConverterTool:
+    """Window for converting images and PDFs to various formats."""
+
+    def __init__(self, master: tk.Misc) -> None:
+        self.master = master
+        self.window = tk.Toplevel(master)
+        self.window.title("Converter")
+
+        frm = tk.Frame(self.window)
+        frm.pack(padx=10, pady=10)
+
+        tk.Button(frm, text="Choose file", command=self.choose_file).grid(row=0, column=0, sticky=tk.W)
+        self.file_label = tk.Label(frm, text="No file")
+        self.file_label.grid(row=0, column=1, columnspan=3)
+
+        tk.Label(frm, text="Format").grid(row=1, column=0, sticky=tk.W)
+        self.format_var = tk.StringVar(value="PNG")
+        formats = ["JPEG", "PNG", "TIFF", "BMP", "GIF", "WEBP", "PDF"]
+        ttk.Combobox(frm, textvariable=self.format_var, values=formats, state="readonly").grid(row=1, column=1, sticky=tk.W)
+
+        tk.Label(frm, text="Width").grid(row=2, column=0, sticky=tk.W)
+        self.width_entry = tk.Entry(frm, width=5)
+        self.width_entry.grid(row=2, column=1, sticky=tk.W)
+        tk.Label(frm, text="Height").grid(row=2, column=2, sticky=tk.W)
+        self.height_entry = tk.Entry(frm, width=5)
+        self.height_entry.grid(row=2, column=3, sticky=tk.W)
+
+        tk.Label(frm, text="DPI").grid(row=3, column=0, sticky=tk.W)
+        self.dpi_entry = tk.Entry(frm, width=5)
+        self.dpi_entry.grid(row=3, column=1, sticky=tk.W)
+        self.gray_var = tk.BooleanVar()
+        tk.Checkbutton(frm, text="Grayscale", variable=self.gray_var).grid(row=3, column=2, sticky=tk.W)
+
+        tk.Button(frm, text="Convert", command=self.convert).grid(row=4, column=0, columnspan=4, pady=5)
+
+        self.input_path: str | None = None
+
+    def choose_file(self) -> None:
+        path = filedialog.askopenfilename(filetypes=[("All", "*.*"), ("Images", "*.png;*.jpg;*.jpeg;*.bmp;*.gif"), ("PDF", "*.pdf")])
+        if path:
+            self.input_path = path
+            self.file_label.config(text=os.path.basename(path))
+
+    def convert(self) -> None:
+        if not self.input_path:
+            messagebox.showwarning("No file", "Please select a file to convert.")
+            return
+        out_format = self.format_var.get().upper()
+        save_path = filedialog.asksaveasfilename(defaultextension=f".{out_format.lower()}")
+        if not save_path:
+            return
+        width = self._parse_int(self.width_entry.get())
+        height = self._parse_int(self.height_entry.get())
+        dpi = self._parse_int(self.dpi_entry.get())
+        grayscale = self.gray_var.get()
+
+        try:
+            if self.input_path.lower().endswith(".pdf"):
+                self._convert_pdf(self.input_path, save_path, out_format, width, height, dpi, grayscale)
+            else:
+                self._convert_image(self.input_path, save_path, out_format, width, height, dpi, grayscale)
+            messagebox.showinfo("Done", f"File saved to {save_path}")
+        except Exception as exc:  # pylint: disable=broad-except
+            messagebox.showerror("Error", f"Conversion failed: {exc}")
+
+    # Helpers ---------------------------------------------------------------
+    def _parse_int(self, value: str) -> int | None:
+        try:
+            return int(value)
+        except ValueError:
+            return None
+
+    def _convert_image(self, src: str, dst: str, fmt: str, width: int | None, height: int | None, dpi: int | None, gray: bool) -> None:
+        img = Image.open(src)
+        img = img.convert("L" if gray else "RGB")
+        if width and height:
+            img = img.resize((width, height))
+        params = {}
+        if dpi:
+            params["dpi"] = (dpi, dpi)
+        img.save(dst, format=fmt, **params)
+
+    def _convert_pdf(self, src: str, dst: str, fmt: str, width: int | None, height: int | None, dpi: int | None, gray: bool) -> None:
+        doc = fitz.open(src)
+        images = []
+        for page in doc:
+            pix = page.get_pixmap(dpi=dpi or 150)
+            img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+            if gray:
+                img = img.convert("L")
+            if width and height:
+                img = img.resize((width, height))
+            images.append(img)
+        if fmt in {"TIFF", "GIF", "PDF"}:
+            images[0].save(dst, format=fmt, save_all=True, append_images=images[1:])
+        else:
+            base, ext = os.path.splitext(dst)
+            for i, img in enumerate(images, start=1):
+                img.save(f"{base}_{i}{os.path.splitext(dst)[1]}", format=fmt)

--- a/toolbox/main.py
+++ b/toolbox/main.py
@@ -1,0 +1,86 @@
+"""Main dashboard application for Toolbox.
+
+Provides buttons to launch individual utilities such as PDF Annotator,
+Screenshot tool and Image/PDF converter. Two additional tiles are
+placeholders to showcase how new tools can be added.
+
+This application targets Windows but uses cross platform libraries where
+possible. Each tool lives in its own module for modularity and future
+extension.
+"""
+
+from tkinter import Tk, Button, messagebox
+from tkinter import N, S, E, W
+
+try:
+    from pdf_annotator import PDFAnnotator
+except Exception as exc:  # pylint: disable=broad-except
+    PDFAnnotator = None
+    pdf_error = exc
+
+try:
+    from screenshot_tool import ScreenshotTool
+except Exception as exc:  # pylint: disable=broad-except
+    ScreenshotTool = None
+    screenshot_error = exc
+
+try:
+    from converter import ConverterTool
+except Exception as exc:  # pylint: disable=broad-except
+    ConverterTool = None
+    converter_error = exc
+
+
+class Dashboard(Tk):
+    """Main dashboard window with tiles arranged in a grid."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Toolbox")
+        self.configure(padx=20, pady=20)
+        self.create_tiles()
+
+    def create_tiles(self) -> None:
+        """Create buttons for the tools."""
+        buttons = [
+            ("PDF Annotator", self.open_pdf_annotator),
+            ("Screenshot", self.open_screenshot),
+            ("Converter", self.open_converter),
+            ("Coming soon", lambda: messagebox.showinfo("Toolbox", "Demo tile")),
+            ("Coming soon", lambda: messagebox.showinfo("Toolbox", "Demo tile")),
+        ]
+
+        rows = 2
+        cols = 3
+        for index, (text, command) in enumerate(buttons):
+            row = index // cols
+            col = index % cols
+            btn = Button(self, text=text, width=20, height=5, command=command)
+            btn.grid(row=row, column=col, padx=10, pady=10, sticky=(N, S, E, W))
+
+        for i in range(rows):
+            self.rowconfigure(i, weight=1)
+        for j in range(cols):
+            self.columnconfigure(j, weight=1)
+
+    def open_pdf_annotator(self) -> None:
+        if PDFAnnotator is None:
+            messagebox.showerror("Missing dependency", f"Cannot open PDF annotator: {pdf_error}")
+            return
+        PDFAnnotator(self)
+
+    def open_screenshot(self) -> None:
+        if ScreenshotTool is None:
+            messagebox.showerror("Missing dependency", f"Cannot open screenshot tool: {screenshot_error}")
+            return
+        ScreenshotTool(self)
+
+    def open_converter(self) -> None:
+        if ConverterTool is None:
+            messagebox.showerror("Missing dependency", f"Cannot open converter: {converter_error}")
+            return
+        ConverterTool(self)
+
+
+if __name__ == "__main__":
+    Dashboard().mainloop()

--- a/toolbox/pdf_annotator.py
+++ b/toolbox/pdf_annotator.py
@@ -1,0 +1,163 @@
+"""Simple PDF viewer and annotator using PyMuPDF and Tkinter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+import tkinter as tk
+from tkinter import filedialog, messagebox, simpledialog
+
+try:
+    import fitz  # PyMuPDF
+except Exception as exc:  # pylint: disable=broad-except
+    raise ImportError(
+        "PyMuPDF is required for the PDF annotator. Please install it before running."  # noqa: E501
+    ) from exc
+
+try:
+    from PIL import Image, ImageTk
+except Exception as exc:  # pylint: disable=broad-except
+    raise ImportError(
+        "Pillow is required for the PDF annotator. Please install it before running."  # noqa: E501
+    ) from exc
+
+
+@dataclass
+class PageAnnotations:
+    """Keep track of strokes and texts for a page."""
+
+    strokes: List[List[Tuple[int, int]]] = field(default_factory=list)
+    texts: List[Tuple[int, int, str]] = field(default_factory=list)
+
+
+class PDFAnnotator:
+    """Window allowing basic PDF viewing and annotation."""
+
+    def __init__(self, master: tk.Misc) -> None:
+        self.master = master
+        self.window = tk.Toplevel(master)
+        self.window.title("PDF Annotator")
+
+        toolbar = tk.Frame(self.window)
+        toolbar.pack(fill=tk.X)
+
+        tk.Button(toolbar, text="Open PDF", command=self.open_pdf).pack(side=tk.LEFT)
+        tk.Button(toolbar, text="Prev", command=self.prev_page).pack(side=tk.LEFT)
+        tk.Button(toolbar, text="Next", command=self.next_page).pack(side=tk.LEFT)
+        tk.Button(toolbar, text="Draw", command=lambda: self.set_mode("draw")).pack(side=tk.LEFT)
+        tk.Button(toolbar, text="Text", command=lambda: self.set_mode("text")).pack(side=tk.LEFT)
+        tk.Button(toolbar, text="Save", command=self.save_pdf).pack(side=tk.LEFT)
+
+        self.canvas = tk.Canvas(self.window, width=800, height=600, bg="white")
+        self.canvas.pack(fill=tk.BOTH, expand=True)
+
+        self.doc: fitz.Document | None = None
+        self.current_page = 0
+        self.page_images: Dict[int, ImageTk.PhotoImage] = {}
+        self.annotations: Dict[int, PageAnnotations] = {}
+        self.mode = "draw"
+        self.current_line: int | None = None
+
+        self.canvas.bind("<ButtonPress-1>", self.on_press)
+        self.canvas.bind("<B1-Motion>", self.on_drag)
+        self.canvas.bind("<ButtonRelease-1>", self.on_release)
+
+    # PDF handling ---------------------------------------------------------
+    def open_pdf(self) -> None:
+        path = filedialog.askopenfilename(filetypes=[("PDF", "*.pdf")])
+        if not path:
+            return
+        try:
+            self.doc = fitz.open(path)
+            self.current_page = 0
+            self.annotations.clear()
+            self.display_page()
+        except Exception as exc:  # pylint: disable=broad-except
+            messagebox.showerror("Error", f"Failed to open PDF: {exc}")
+
+    def display_page(self) -> None:
+        if not self.doc:
+            return
+        page = self.doc[self.current_page]
+        zoom = 1.5
+        pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom))
+        img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+        self.page_images[self.current_page] = ImageTk.PhotoImage(img)
+        self.canvas.delete("all")
+        self.canvas.create_image(0, 0, anchor=tk.NW, image=self.page_images[self.current_page])
+        self.canvas.config(scrollregion=self.canvas.bbox(tk.ALL))
+        self.redraw_annotations()
+
+    def prev_page(self) -> None:
+        if not self.doc:
+            return
+        if self.current_page > 0:
+            self.current_page -= 1
+            self.display_page()
+
+    def next_page(self) -> None:
+        if not self.doc:
+            return
+        if self.current_page < len(self.doc) - 1:
+            self.current_page += 1
+            self.display_page()
+
+    # Drawing --------------------------------------------------------------
+    def set_mode(self, mode: str) -> None:
+        self.mode = mode
+
+    def on_press(self, event: tk.Event) -> None:  # type: ignore[override]
+        if self.mode == "draw":
+            self.current_line = self.canvas.create_line(event.x, event.y, event.x, event.y, fill="red", width=2)
+        elif self.mode == "text":
+            text = simpledialog.askstring("Text", "Enter text")
+            if text:
+                self.canvas.create_text(event.x, event.y, text=text, fill="blue", anchor=tk.NW)
+                page_ann = self.annotations.setdefault(self.current_page, PageAnnotations())
+                page_ann.texts.append((event.x, event.y, text))
+
+    def on_drag(self, event: tk.Event) -> None:  # type: ignore[override]
+        if self.mode == "draw" and self.current_line is not None:
+            coords = self.canvas.coords(self.current_line) + [event.x, event.y]
+            self.canvas.coords(self.current_line, *coords)
+
+    def on_release(self, _event: tk.Event) -> None:  # type: ignore[override]
+        if self.mode == "draw" and self.current_line is not None:
+            coords = self.canvas.coords(self.current_line)
+            points = [(int(coords[i]), int(coords[i + 1])) for i in range(0, len(coords), 2)]
+            page_ann = self.annotations.setdefault(self.current_page, PageAnnotations())
+            page_ann.strokes.append(points)
+            self.current_line = None
+
+    def redraw_annotations(self) -> None:
+        page_ann = self.annotations.get(self.current_page)
+        if not page_ann:
+            return
+        for stroke in page_ann.strokes:
+            flat = [v for point in stroke for v in point]
+            self.canvas.create_line(*flat, fill="red", width=2)
+        for x, y, text in page_ann.texts:
+            self.canvas.create_text(x, y, text=text, fill="blue", anchor=tk.NW)
+
+    # Saving ---------------------------------------------------------------
+    def save_pdf(self) -> None:
+        if not self.doc:
+            return
+        save_path = filedialog.asksaveasfilename(defaultextension=".pdf", filetypes=[("PDF", "*.pdf")])
+        if not save_path:
+            return
+        try:
+            for page_num, ann in self.annotations.items():
+                page = self.doc[page_num]
+                shape = page.new_shape()
+                for stroke in ann.strokes:
+                    pdf_points = [fitz.Point(x, y) for x, y in stroke]
+                    shape.draw_polyline(pdf_points, color=(1, 0, 0), width=2)
+                for x, y, text in ann.texts:
+                    page.insert_text((x, y), text, fontsize=12, color=(0, 0, 1))
+                shape.commit()
+            self.doc.save(save_path)
+            messagebox.showinfo("Saved", f"Annotations saved to {save_path}")
+        except Exception as exc:  # pylint: disable=broad-except
+            messagebox.showerror("Error", f"Failed to save: {exc}")

--- a/toolbox/screenshot_tool.py
+++ b/toolbox/screenshot_tool.py
@@ -1,0 +1,81 @@
+"""Screenshot utility using Tkinter and Pillow."""
+
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+try:
+    from PIL import ImageGrab
+except Exception as exc:  # pylint: disable=broad-except
+    raise ImportError(
+        "Pillow is required for the screenshot tool. Please install it before running."  # noqa: E501
+    ) from exc
+
+
+class ScreenshotTool:
+    """Window that provides full screen and region screenshot capabilities."""
+
+    def __init__(self, master: tk.Misc) -> None:
+        self.master = master
+        self.window = tk.Toplevel(master)
+        self.window.title("Screenshot")
+        tk.Button(self.window, text="Full Screen", command=self.full_screen).pack(fill=tk.X)
+        tk.Button(self.window, text="Region", command=self.region).pack(fill=tk.X)
+
+    def full_screen(self) -> None:
+        path = filedialog.asksaveasfilename(defaultextension=".png", filetypes=[("PNG", "*.png"), ("JPEG", "*.jpg")])
+        if not path:
+            return
+        try:
+            img = ImageGrab.grab()
+            img.save(path)
+            messagebox.showinfo("Saved", f"Screenshot saved to {path}")
+        except Exception as exc:  # pylint: disable=broad-except
+            messagebox.showerror("Error", f"Failed to capture screenshot: {exc}")
+
+    def region(self) -> None:
+        selector = _RegionSelector(self.master)
+        self.master.wait_window(selector.top)
+        if selector.bbox:
+            path = filedialog.asksaveasfilename(defaultextension=".png", filetypes=[("PNG", "*.png"), ("JPEG", "*.jpg")])
+            if not path:
+                return
+            try:
+                img = ImageGrab.grab(bbox=selector.bbox)
+                img.save(path)
+                messagebox.showinfo("Saved", f"Screenshot saved to {path}")
+            except Exception as exc:  # pylint: disable=broad-except
+                messagebox.showerror("Error", f"Failed to capture screenshot: {exc}")
+
+
+class _RegionSelector:
+    """Transparent fullscreen window to select a region."""
+
+    def __init__(self, master: tk.Misc) -> None:
+        self.top = tk.Toplevel(master)
+        self.top.attributes("-fullscreen", True)
+        self.top.attributes("-alpha", 0.3)
+        self.top.configure(bg="gray")
+        self.start_x = self.start_y = 0
+        self.bbox = None
+
+        self.canvas = tk.Canvas(self.top, cursor="cross")
+        self.canvas.pack(fill=tk.BOTH, expand=True)
+        self.rect = None
+
+        self.canvas.bind("<ButtonPress-1>", self.on_press)
+        self.canvas.bind("<B1-Motion>", self.on_drag)
+        self.canvas.bind("<ButtonRelease-1>", self.on_release)
+
+    def on_press(self, event: tk.Event) -> None:  # type: ignore[override]
+        self.start_x, self.start_y = event.x, event.y
+        self.rect = self.canvas.create_rectangle(self.start_x, self.start_y, self.start_x, self.start_y, outline="red")
+
+    def on_drag(self, event: tk.Event) -> None:  # type: ignore[override]
+        if self.rect is not None:
+            self.canvas.coords(self.rect, self.start_x, self.start_y, event.x, event.y)
+
+    def on_release(self, event: tk.Event) -> None:  # type: ignore[override]
+        if self.rect is not None:
+            end_x, end_y = event.x, event.y
+            self.bbox = (min(self.start_x, end_x), min(self.start_y, end_y), max(self.start_x, end_x), max(self.start_y, end_y))
+        self.top.destroy()


### PR DESCRIPTION
## Summary
- Create Tkinter dashboard with five tiles launching PDF annotation, screenshot and conversion tools
- Implement PDF viewer/annotator using PyMuPDF and Pillow
- Add screenshot utility for full-screen or region capture
- Provide image/PDF converter supporting resizing, DPI and grayscale
- Include packaging script and documentation

## Testing
- `python -m py_compile toolbox/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae438f2a3c832d863a939ff8dd97e6